### PR TITLE
Redeclared Scoped Symbol Table Variables

### DIFF
--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -518,7 +518,6 @@ public class Parser {
                                 if(tokens.get(0).tokenType == TokenType.TK_TYPE) {
                                         Declaration dec = declarationGrammar(parentTable);
                                         ((Statement.Block) statement).addDeclaration(dec);
-                                        parentTable.addSymbol((Declaration.varDeclaration) dec);
 
                                 } else if(tokens.get(0).str.equals("for")) {
                                         // handle the for-loop here so if there happens to be a declaration, the declaration can be added to the parent scope
@@ -902,6 +901,11 @@ public class Parser {
                                         varDeclaration = varDecNoInit(varDeclaration, typeSpec, decID, false);
                                         parentTable.addSymbol(typeSpec, decID);
 
+
+                                        if (previous.tokenType == TokenType.TK_SEMICOLON) {
+                                            return varDeclaration;
+                                        }
+
                                         if (tokens.size() > 0) {
                                                 if (tokens.size() > 1 && tokens.get(1).tokenType == TokenType.TK_EQUALS) {
                                                         previous = tokens.get(1);
@@ -917,10 +921,10 @@ public class Parser {
                                         }
                                 }
 
-                                // Need this since in the case 'int a;' previous == ;
-                                // Which means if this is a condition in while() then
-                                // we will never make it inside of here.
-                                if (previous.tokenType == TokenType.TK_SEMICOLON) break;
+                            // Need this since in the case 'int a;' previous == ;
+                            // Which means if this is a condition in while() then
+                            // we will never make it inside of here.
+                            if (previous.tokenType == TokenType.TK_SEMICOLON) break;
                         } while (tokens.get(0).tokenType != TokenType.TK_SEMICOLON);
 
                         // remove semicolon

--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -883,7 +883,7 @@ public class Parser {
                 else {
 
                         Declaration.varDeclaration varDeclaration = new Declaration.varDeclaration();
-                        parentTable.addSymbol(typeSpec, decID);
+                        //parentTable.addSymbol(typeSpec, decID);
                         do {
                                 if (previous.tokenType == TokenType.TK_EQUALS) {
                                         varDeclaration = varDecInit(varDeclaration, typeSpec, decID); // Init our var with the correct value.
@@ -900,7 +900,7 @@ public class Parser {
 
                                 } else {
                                         varDeclaration = varDecNoInit(varDeclaration, typeSpec, decID, false);
-                                        parentTable.addSymbol(varDeclaration);
+                                        parentTable.addSymbol(typeSpec, decID);
 
                                         if (tokens.size() > 0) {
                                                 if (tokens.size() > 1 && tokens.get(1).tokenType == TokenType.TK_EQUALS) {

--- a/src/parser/SymbolTable.java
+++ b/src/parser/SymbolTable.java
@@ -32,7 +32,7 @@ public class SymbolTable {
 
         for(Token token : ST.keySet()) {
             if (token.str.equals(ID.str)) {
-                System.err.println("This variable already exists : "+ ID);
+                System.err.println("This variable already exists : "+ ID.tokError());
                 System.exit(1);
             }
         }

--- a/src/parser/SymbolTable.java
+++ b/src/parser/SymbolTable.java
@@ -29,6 +29,13 @@ public class SymbolTable {
 
     //add a new element to current hash map
     public void addSymbol(Token type, Token ID){
+
+        for(Token token : ST.keySet()) {
+            if (token.str.equals(ID.str)) {
+                System.err.println("This variable already exists : "+ ID);
+                System.exit(1);
+            }
+        }
         this.ST.put(ID, type);
     }
 
@@ -37,10 +44,21 @@ public class SymbolTable {
 
         Token type = var.getType();
         Token ID = var.getVariableID();
+        //compare every key to the ID to ensure there are no duplicate variable names
+
+        for(Token token : ST.keySet()) {
+                if (token.str.equals(ID.str)) {
+                    System.err.println("This variable already exists : "+ ID.tokError());
+                    System.err.println("Current symbol table : " + ST);
+
+                    System.exit(1);
+                }
+        }
+
         this.ST.put(ID, type);
     }
 
-    //retreve a specific element
+    //retrieve a specific element
     public Token hasSymbol(Token ID){
         return this.ST.get(ID);
     }

--- a/src/parser/treeObjects/Statement.java
+++ b/src/parser/treeObjects/Statement.java
@@ -28,7 +28,9 @@ public abstract class Statement extends Node {
                 }
 
                 public void addDeclaration(Declaration declaration) {
-                        this.addChild(declaration);
+                        if(declaration != null) {
+                                this.addChild(declaration);
+                        }
                 }
 
                 @Override


### PR DESCRIPTION
The Symbol Table now errors if we have redeclared variables that were already defined inside the same scope.